### PR TITLE
[Bug Fix] For Edge Apps

### DIFF
--- a/tampermonkey.user.js
+++ b/tampermonkey.user.js
@@ -2,7 +2,7 @@
 // @name         Mew enchantment AutoUpdate ver.
 // @namespace    http://tampermonkey.net/
 // @homepage     https://github.com/yige233/bettermew
-// @version      0.35
+// @version      0.36
 // @description  个人向脚本，随着网页的更新，可能会失效。主要功能：https://mew.fun/Dove_yige/thoughts/69082567613583360
 // @author       破损的鞘翅
 // @match        https://mew.fun/n/*

--- a/tampermonkey.user.js
+++ b/tampermonkey.user.js
@@ -10,8 +10,8 @@
 // @match        https://*.mew.fun/sector-explore*
 // @icon         https://mew.fun/favicon.png
 // @supportURL   https://github.com/yige233/bettermew/issues
-// @updateURL    https://cdn.jsdelivr.net/gh/yige233/bettermew@latest/tampermonkey.js
-// @downloadURL  https://cdn.jsdelivr.net/gh/yige233/bettermew@latest/tampermonkey.js
+// @updateURL    https://cdn.jsdelivr.net/gh/yige233/bettermew@latest/tampermonkey.user.js
+// @downloadURL  https://cdn.jsdelivr.net/gh/yige233/bettermew@latest/tampermonkey.user.js
 // @grant        GM.registerMenuCommand
 // @grant        GM.getValue
 // @grant        GM.setValue

--- a/tampermonkey.user.js
+++ b/tampermonkey.user.js
@@ -5,14 +5,9 @@
 // @version      0.36
 // @description  个人向脚本，随着网页的更新，可能会失效。主要功能：https://mew.fun/Dove_yige/thoughts/69082567613583360
 // @author       破损的鞘翅
-// @match        https://mew.fun/n/*
-// @match        https://mew.fun/home
-// @match        https://mew.fun/home?utm_source=pwa
-// @match        https://mew.fun/sector-explore
-// @match        https://beta.mew.fun/n/*
-// @match        https://beta.mew.fun/home
-// @match        https://beta.mew.fun/home?utm_source=pwa
-// @match        https://beta.mew.fun/sector-explore
+// @match        https://*.mew.fun/n/*
+// @match        https://*.mew.fun/home*
+// @match        https://*.mew.fun/sector-explore*
 // @icon         https://mew.fun/favicon.png
 // @supportURL   https://github.com/yige233/bettermew/issues
 // @updateURL    https://cdn.jsdelivr.net/gh/yige233/bettermew@latest/tampermonkey.js

--- a/tampermonkey.user.js
+++ b/tampermonkey.user.js
@@ -7,9 +7,11 @@
 // @author       破损的鞘翅
 // @match        https://mew.fun/n/*
 // @match        https://mew.fun/home
+// @match        https://mew.fun/home?utm_source=pwa
 // @match        https://mew.fun/sector-explore
 // @match        https://beta.mew.fun/n/*
 // @match        https://beta.mew.fun/home
+// @match        https://beta.mew.fun/home?utm_source=pwa
 // @match        https://beta.mew.fun/sector-explore
 // @icon         https://mew.fun/favicon.png
 // @supportURL   https://github.com/yige233/bettermew/issues


### PR DESCRIPTION
Add
// @match        https://mew.fun/home?utm_source=pwa
// @match        https://beta.mew.fun/home?utm_source=pwa
*修复浏览器安装为应用情况下，启动应用MEW时添加额外的启动参数，导致脚本不加载的问题
微软我 *尚蜀粗口*，你好歹加了启动参数给标出来啊，藏着掖着干嘛
